### PR TITLE
Fixing bug with Julian dates less than 3 digits

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -57,12 +57,11 @@ func convertNumToZeroPaddedString(in int64, requiredLength int) string {
 }
 
 // default length of date string in eft format is 6 0yyddd
-// this function assumes that the year will always be in the 20's (2010, 2020, 2050 etc.)
 func convertTimestampToEftDate(in time.Time) string {
 	year := in.Year() % 100
 	day := in.YearDay()
 
-	return fmt.Sprintf("0%d%d", year, day)
+	return fmt.Sprintf("%03d%03d", year, day)
 }
 
 func isFillerString(s string) bool {


### PR DESCRIPTION
Julian dates that are less than 3 digits for, example Jan 4, 2024, should be 024004 but the library generates 0246 which is incorrect. 