### PR TITLE
fix(cadeft): prevent short-line panics in reader/streamer; add fuzzer

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,39 @@
+name: Go Fuzz Testing
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  fuzz:
+    name: Fuzz
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        command:
+          - "go test . -fuzz FuzzReader -fuzztime 10m"
+
+    steps:
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v7
+      with:
+        go-version: stable
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
+
+    - name: Fuzz
+      run: ${{ matrix.command }}
+
+    - name: Report Failures
+      if: ${{ failure() }}
+      run: |
+        find . -path '*/testdata/fuzz/*' -type f 2>/dev/null | xargs -r -n1 tail -n +1 -v || true

--- a/file_streamer.go
+++ b/file_streamer.go
@@ -126,12 +126,20 @@ func (fs *FileStreamer) ScanTxn() (Transaction, error) {
 			return nil, io.EOF
 		}
 
+		if len(fs.lineContents) < commonRecordDataLength {
+			return nil, fmt.Errorf("txn record at line %d shorter than common header length %d", fs.currentLine, commonRecordDataLength)
+		}
+
 		if len(fs.lineContents[commonRecordDataLength:])%segmentLength != 0 {
 			return nil, fmt.Errorf("txn record at line %d is not of correct length", fs.currentLine)
 		}
 
 		fs.numTxnsPerLine = len(fs.lineContents[commonRecordDataLength:]) / segmentLength
 
+	}
+
+	if len(fs.lineContents) < 1 {
+		return nil, io.EOF
 	}
 
 	recordType, err := parseRecordType(fs.lineContents[:1])
@@ -146,9 +154,15 @@ func (fs *FileStreamer) ScanTxn() (Transaction, error) {
 	defer fs.incrementTxnCount()
 
 	// determine starting index and ending index from currentTxn
+	if len(fs.lineContents) < commonRecordDataLength {
+		return nil, fmt.Errorf("txn record at line %d shorter than common header length %d", fs.currentLine, commonRecordDataLength)
+	}
 	txnsSegment := fs.lineContents[commonRecordDataLength:]
 	startIdx := segmentLength * fs.currentTxn
 	endIdx := segmentLength * (fs.currentTxn + 1)
+	if endIdx > len(txnsSegment) {
+		return nil, fmt.Errorf("txn segment bounds out of range at line %d", fs.currentLine)
+	}
 
 	var txn Transaction
 	switch recordType {

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -1,0 +1,64 @@
+package cadeft_test
+
+import (
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/moov-io/cadeft"
+)
+
+func FuzzReader(f *testing.F) {
+	populateCorpus(f)
+
+	f.Fuzz(func(t *testing.T, contents string) {
+		if len(contents) > 1<<20 {
+			t.Skip()
+		}
+
+		r := cadeft.NewReader(strings.NewReader(contents))
+		_, _ = r.ReadFile()
+
+		// Streamer path — more tolerant of errors; needs ReadSeeker
+		stream := cadeft.NewFileStream(strings.NewReader(contents))
+		_, _ = stream.GetHeader()
+		for i := 0; i < 100; i++ {
+			txn, err := stream.ScanTxn()
+			if err != nil {
+				if err == io.EOF {
+					break
+				}
+				// continue scanning after parse errors if possible
+				if txn == nil {
+					break
+				}
+			}
+			if txn == nil {
+				break
+			}
+		}
+		_, _ = stream.GetFooter()
+	})
+}
+
+func populateCorpus(f *testing.F) {
+	f.Helper()
+
+	f.Add("")
+	f.Add("A0000000010000000610000102313861210                    CAD\n")
+
+	_ = filepath.Walk("sample_files", func(path string, info fs.FileInfo, err error) error {
+		if err != nil || info == nil || info.IsDir() {
+			return nil
+		}
+		bs, err := os.ReadFile(path)
+		if err != nil || len(bs) > 512*1024 {
+			return nil
+		}
+		f.Add(string(bs))
+		return nil
+	})
+}

--- a/reader.go
+++ b/reader.go
@@ -27,6 +27,9 @@ func (r *Reader) ReadFile() (File, error) {
 		if err != nil {
 			return File{}, fmt.Errorf("failed to read line: %w", err)
 		}
+		if len(line) == 0 {
+			continue
+		}
 		recordType := line[:1]
 		if recordType == string(HeaderRecord) {
 			if err := r.parseARecord(line); err != nil {
@@ -58,6 +61,9 @@ func (r *Reader) parseARecord(data string) error {
 }
 
 func (r *Reader) parseTxnRecord(data string) error {
+	if len(data) < commonRecordDataLength {
+		return fmt.Errorf("txn record shorter than common header length %d: got %d", commonRecordDataLength, len(data))
+	}
 	if len(data[commonRecordDataLength:])%segmentLength != 0 {
 		return fmt.Errorf("record length is not valid multiple of 260, partial txn: %d", len(data[commonRecordDataLength:]))
 	}

--- a/reader_fuzz_regression_test.go
+++ b/reader_fuzz_regression_test.go
@@ -1,0 +1,18 @@
+package cadeft
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadFile_ShortTxnLineNoPanic(t *testing.T) {
+	inputs := []string{"", "C", "D", "A", "Z", "Cshort"}
+	for _, in := range inputs {
+		require.NotPanics(t, func() {
+			r := NewReader(strings.NewReader(in))
+			_, _ = r.ReadFile()
+		}, "input %q", in)
+	}
+}

--- a/testdata/fuzz/FuzzReader/eda1f9afe7b01a99
+++ b/testdata/fuzz/FuzzReader/eda1f9afe7b01a99
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("C")


### PR DESCRIPTION
## Summary
Guard txn parsing when lines are shorter than the common header length (previously panicked on inputs like `C`). Add a native fuzzer seeded from `sample_files` and a regression test.

## Test plan
- [x] `go test` for affected packages
- [x] `go test -run='^$' -fuzz=Fuzz... -fuzztime=3s` smoke on new/updated fuzzers
- [x] Regression tests for any panics fixed by fuzzing