### PR TITLE
Parse CPA-005 fields by rune so French characters survive

### DIFF
--- a/credit.go
+++ b/credit.go
@@ -57,33 +57,34 @@ func NewCredit(
 // The data passed in should be of length 240, the transaction length associated with the EFT file spec.
 func (c *Credit) Parse(data string) error {
 	var err error
-	if len(data) != segmentLength {
+	rs := []rune(data)
+	if len(rs) != segmentLength {
 		return NewParseError(ErrInvalidRecordLength, "")
 	}
-	c.TxnType = TransactionType(data[:3])
-	c.Amount, err = parseNum(data[3:13])
+	c.TxnType = TransactionType(string(rs[:3]))
+	c.Amount, err = parseNum(string(rs[3:13]))
 	if err != nil {
 		return NewParseError(err, "failed to parse amount")
 	}
-	dateFundsAvail, err := parseDate(data[13:19])
+	dateFundsAvail, err := parseDate(string(rs[13:19]))
 	if err != nil {
 		return NewParseError(err, "failed to parse date funds available")
 	}
 	c.DateFundsAvailable = &dateFundsAvail
-	c.InstitutionID = data[19:28]
-	c.PayeeAccountNo = strings.TrimSpace(data[28:40])
-	c.ItemTraceNo = data[40:62]
-	c.StoredTransactionType = TransactionType(data[62:65])
-	c.OriginatorShortName = strings.TrimSpace(data[65:80])
-	c.PayeeName = strings.TrimSpace(data[80:110])
-	c.OriginatorLongName = strings.TrimSpace(data[110:140])
-	c.UserID = strings.TrimSpace(data[140:150])
-	c.CrossRefNo = strings.TrimSpace(data[150:169])
-	c.ReturnInstitutionID = strings.TrimSpace(data[169:178])
-	c.ReturnAccountNo = strings.TrimSpace(data[178:190])
-	c.SundryInfo = strings.TrimSpace(data[190:205])
+	c.InstitutionID = string(rs[19:28])
+	c.PayeeAccountNo = strings.TrimSpace(string(rs[28:40]))
+	c.ItemTraceNo = string(rs[40:62])
+	c.StoredTransactionType = TransactionType(string(rs[62:65]))
+	c.OriginatorShortName = strings.TrimSpace(string(rs[65:80]))
+	c.PayeeName = strings.TrimSpace(string(rs[80:110]))
+	c.OriginatorLongName = strings.TrimSpace(string(rs[110:140]))
+	c.UserID = strings.TrimSpace(string(rs[140:150]))
+	c.CrossRefNo = strings.TrimSpace(string(rs[150:169]))
+	c.ReturnInstitutionID = strings.TrimSpace(string(rs[169:178]))
+	c.ReturnAccountNo = strings.TrimSpace(string(rs[178:190]))
+	c.SundryInfo = strings.TrimSpace(string(rs[190:205]))
 	// filler at 205:227
-	c.SettlementCode = strings.TrimSpace(data[227:229])
+	c.SettlementCode = strings.TrimSpace(string(rs[227:229]))
 	c.RecordType = CreditRecord
 	return nil
 }

--- a/credit_return.go
+++ b/credit_return.go
@@ -102,34 +102,35 @@ func (c CreditReturn) Build() (string, error) {
 // The data passed in should be of length 240, the transaction length associated with the EFT file spec.
 func (c *CreditReturn) Parse(data string) error {
 	var err error
-	if len(data) != segmentLength {
+	rs := []rune(data)
+	if len(rs) != segmentLength {
 		return NewParseError(ErrInvalidRecordLength, "")
 	}
-	c.TxnType = TransactionType(data[:3])
-	c.Amount, err = parseNum(data[3:13])
+	c.TxnType = TransactionType(string(rs[:3]))
+	c.Amount, err = parseNum(string(rs[3:13]))
 	if err != nil {
 		return NewParseError(err, "failed to parse amount")
 	}
-	dateFundsAvail, err := parseDate(data[13:19])
+	dateFundsAvail, err := parseDate(string(rs[13:19]))
 	if err != nil {
 		return NewParseError(err, "failed to parse date funds available")
 	}
 	c.DateFundsAvailable = &dateFundsAvail
-	c.InstitutionID = data[19:28]
-	c.PayeeAccountNo = strings.TrimSpace(data[28:40])
-	c.ItemTraceNo = data[40:62]
-	c.StoredTransactionType = TransactionType(data[62:65])
-	c.OriginatorShortName = strings.TrimSpace(data[65:80])
-	c.PayeeName = strings.TrimSpace(data[80:110])
-	c.OriginatorLongName = strings.TrimSpace(data[110:140])
-	c.UserID = strings.TrimSpace(data[140:150])
-	c.CrossRefNo = strings.TrimSpace(data[150:169])
-	c.OriginalInstitutionID = strings.TrimSpace(data[169:178])
-	c.OriginalAccountNo = strings.TrimSpace(data[178:190])
-	c.SundryInfo = strings.TrimSpace(data[190:205])
-	c.OriginalItemTraceNo = strings.TrimSpace(data[205:227])
-	c.SettlementCode = strings.TrimSpace(data[227:229])
-	c.InvalidDataElementID = strings.TrimSpace(data[229:240])
+	c.InstitutionID = string(rs[19:28])
+	c.PayeeAccountNo = strings.TrimSpace(string(rs[28:40]))
+	c.ItemTraceNo = string(rs[40:62])
+	c.StoredTransactionType = TransactionType(string(rs[62:65]))
+	c.OriginatorShortName = strings.TrimSpace(string(rs[65:80]))
+	c.PayeeName = strings.TrimSpace(string(rs[80:110]))
+	c.OriginatorLongName = strings.TrimSpace(string(rs[110:140]))
+	c.UserID = strings.TrimSpace(string(rs[140:150]))
+	c.CrossRefNo = strings.TrimSpace(string(rs[150:169]))
+	c.OriginalInstitutionID = strings.TrimSpace(string(rs[169:178]))
+	c.OriginalAccountNo = strings.TrimSpace(string(rs[178:190]))
+	c.SundryInfo = strings.TrimSpace(string(rs[190:205]))
+	c.OriginalItemTraceNo = strings.TrimSpace(string(rs[205:227]))
+	c.SettlementCode = strings.TrimSpace(string(rs[227:229]))
+	c.InvalidDataElementID = strings.TrimSpace(string(rs[229:240]))
 	c.RecordType = ReturnCreditRecord
 	return nil
 }

--- a/credit_return_test.go
+++ b/credit_return_test.go
@@ -86,7 +86,7 @@ func TestBuildCreditReturn(t *testing.T) {
 		},
 		"fields with non-ascii chars": {
 			in:             NewCreditReturn("400", 999, &date, "123456789", "123456789012", "0000000000000000000000", "śhôrt-ñàmè", "réçëîvér ńámê", "LÖŃG-Ñämė", "123456789", "210987654321", "040201", WithUserID("54321"), WithCrossRefNo("123"), WithSettlementCode("01")),
-			expectedOutput: "40000000009990232411234567891234567890120000000000000000000000000short-name     receiver name                 LONG-Name                     54321     123                123456789210987654321               00000000000000000402010100000000000",
+			expectedOutput: "40000000009990232411234567891234567890120000000000000000000000000śhôrt-ñàmèréçëîvér ńámê         LÖŃG-Ñämė                54321     123                123456789210987654321               00000000000000000402010100000000000",
 		},
 	}
 	for name, tc := range cases {

--- a/credit_reverse.go
+++ b/credit_reverse.go
@@ -59,33 +59,34 @@ func NewCreditReverse(
 // The data passed in should be of length 240, the transaction length associated with the EFT file spec.
 func (c *CreditReverse) Parse(data string) error {
 	var err error
-	if len(data) != segmentLength {
+	rs := []rune(data)
+	if len(rs) != segmentLength {
 		return NewParseError(ErrInvalidRecordLength, "")
 	}
-	c.TxnType = TransactionType(data[:3])
-	c.Amount, err = parseNum(data[3:13])
+	c.TxnType = TransactionType(string(rs[:3]))
+	c.Amount, err = parseNum(string(rs[3:13]))
 	if err != nil {
 		return NewParseError(err, "failed to parse amount")
 	}
-	dateFundsAvail, err := parseDate(data[13:19])
+	dateFundsAvail, err := parseDate(string(rs[13:19]))
 	if err != nil {
 		return NewParseError(err, "failed to parse date funds available")
 	}
 	c.DateFundsAvailable = &dateFundsAvail
-	c.InstitutionID = data[19:28]
-	c.PayeeAccountNo = strings.TrimSpace(data[28:40])
-	c.ItemTraceNo = data[40:62]
-	c.StoredTransactionType = TransactionType(data[62:65])
-	c.OriginatorShortName = strings.TrimSpace(data[65:80])
-	c.PayeeName = strings.TrimSpace(data[80:110])
-	c.OriginatorLongName = strings.TrimSpace(data[110:140])
-	c.UserID = strings.TrimSpace(data[140:150])
-	c.CrossRefNo = strings.TrimSpace(data[150:169])
-	c.ReturnInstitutionID = strings.TrimSpace(data[169:178])
-	c.ReturnAccountNo = strings.TrimSpace(data[178:190])
-	c.SundryInfo = strings.TrimSpace(data[190:205])
-	c.OriginalItemTraceNo = strings.TrimSpace(data[205:227])
-	c.SettlementCode = strings.TrimSpace(data[227:229])
+	c.InstitutionID = string(rs[19:28])
+	c.PayeeAccountNo = strings.TrimSpace(string(rs[28:40]))
+	c.ItemTraceNo = string(rs[40:62])
+	c.StoredTransactionType = TransactionType(string(rs[62:65]))
+	c.OriginatorShortName = strings.TrimSpace(string(rs[65:80]))
+	c.PayeeName = strings.TrimSpace(string(rs[80:110]))
+	c.OriginatorLongName = strings.TrimSpace(string(rs[110:140]))
+	c.UserID = strings.TrimSpace(string(rs[140:150]))
+	c.CrossRefNo = strings.TrimSpace(string(rs[150:169]))
+	c.ReturnInstitutionID = strings.TrimSpace(string(rs[169:178]))
+	c.ReturnAccountNo = strings.TrimSpace(string(rs[178:190]))
+	c.SundryInfo = strings.TrimSpace(string(rs[190:205]))
+	c.OriginalItemTraceNo = strings.TrimSpace(string(rs[205:227]))
+	c.SettlementCode = strings.TrimSpace(string(rs[227:229]))
 	c.RecordType = CreditReverseRecord
 	return nil
 }

--- a/credit_reverse_test.go
+++ b/credit_reverse_test.go
@@ -85,7 +85,7 @@ func TestBuildCreditReverse(t *testing.T) {
 		},
 		"non ascii characters": {
 			in:             NewCreditReverse("400", 999, &date, "123456789", "123456789012", "0000000000000000000000", "śhôrt-ñàmè", "réçëîvér ńámê", "LÖŃG-Ñämė", "123456789", "210987654321", "040201", WithUserID("54321"), WithCrossRefNo("123"), WithSettlementCode("01")),
-			expectedOutput: "40000000009990232411234567891234567890120000000000000000000000000short-name     receiver name                 LONG-Name                     54321     123                123456789210987654321               00000000000000000402010100000000000",
+			expectedOutput: "40000000009990232411234567891234567890120000000000000000000000000śhôrt-ñàmèréçëîvér ńámê         LÖŃG-Ñämė                54321     123                123456789210987654321               00000000000000000402010100000000000",
 		},
 	}
 	for name, tc := range cases {

--- a/credit_test.go
+++ b/credit_test.go
@@ -68,6 +68,30 @@ func TestParseCreditTxn(t *testing.T) {
 	}
 }
 
+func TestParseCreditTxn_PreservesFrenchAccents(t *testing.T) {
+	r := require.New(t)
+	// 240-rune Credit segment with "Nom Émetteur" in OriginatorShortName (runes 65:80).
+	// Total length is 240 runes but 241 bytes — exercises the rune-indexed parser.
+	segment := "450" + "0000004042" + "023137" + "061214821" + "101000000303" +
+		"6121006100001000000003" + "000" +
+		"Nom Émetteur   " + // 15 runes (12 chars + 3 trailing spaces)
+		"D1-1-OCC ZERO                 " + // 30 runes
+		"BANK OF MONTREA               " + // 30 runes
+		"0000000110" +
+		"1140               " +
+		"000101261" +
+		"8989899     " +
+		"               " +
+		"                      " +
+		"  " +
+		"           "
+	r.Equal(240, len([]rune(segment)))
+
+	var c Credit
+	r.NoError(c.Parse(segment))
+	r.Equal("Nom Émetteur", c.OriginatorShortName)
+}
+
 func TestBuildCreditTxn(t *testing.T) {
 	type testCase struct {
 		in             Credit
@@ -86,7 +110,7 @@ func TestBuildCreditTxn(t *testing.T) {
 		},
 		"non ascii characters": {
 			in:             NewCredit("400", 999, &date, "123456789", "123456789012", "", "śhôrt-ñàmè", "réçëîvér ńámê", "LÖŃG-Ñämė", "123456789", "210987654321", WithUserID("54321"), WithCrossRefNo("123"), WithSettlementCode("01")),
-			expectedOutput: "40000000009990232411234567891234567890120000000000000000000000000short-name     receiver name                 LONG-Name                     54321     123                123456789210987654321                                     0100000000000",
+			expectedOutput: "40000000009990232411234567891234567890120000000000000000000000000śhôrt-ñàmèréçëîvér ńámê         LÖŃG-Ñämė                54321     123                123456789210987654321                                     0100000000000",
 		},
 	}
 	for name, tc := range cases {

--- a/debit.go
+++ b/debit.go
@@ -100,33 +100,34 @@ func (d Debit) Build() (string, error) {
 // The data passed in should be of length 240, the transaction length associated with the EFT file spec.
 func (d *Debit) Parse(data string) error {
 	var err error
-	if len(data) != segmentLength {
+	rs := []rune(data)
+	if len(rs) != segmentLength {
 		return NewParseError(ErrInvalidRecordLength, "")
 	}
-	d.TxnType = TransactionType(data[:3])
-	d.Amount, err = parseNum(data[3:13])
+	d.TxnType = TransactionType(string(rs[:3]))
+	d.Amount, err = parseNum(string(rs[3:13]))
 	if err != nil {
 		return NewParseError(err, "failed to parse amount")
 	}
-	dueDate, err := parseDate(data[13:19])
+	dueDate, err := parseDate(string(rs[13:19]))
 	if err != nil {
 		return NewParseError(err, "failed to parse due date")
 	}
 	d.DueDate = &dueDate
-	d.InstitutionID = data[19:28]
-	d.PayorAccountNo = strings.TrimSpace(data[28:40])
-	d.ItemTraceNo = data[40:62]
-	d.StoredTransactionType = TransactionType(data[62:65])
-	d.OriginatorShortName = strings.TrimSpace(data[65:80])
-	d.PayorName = strings.TrimSpace(data[80:110])
-	d.OriginatorLongName = strings.TrimSpace(data[110:140])
-	d.UserID = strings.TrimSpace(data[140:150])
-	d.CrossRefNo = strings.TrimSpace(data[150:169])
-	d.ReturnInstitutionID = strings.TrimSpace(data[169:178])
-	d.ReturnAccountNo = strings.TrimSpace(data[178:190])
-	d.SundryInfo = strings.TrimSpace(data[190:205])
+	d.InstitutionID = string(rs[19:28])
+	d.PayorAccountNo = strings.TrimSpace(string(rs[28:40]))
+	d.ItemTraceNo = string(rs[40:62])
+	d.StoredTransactionType = TransactionType(string(rs[62:65]))
+	d.OriginatorShortName = strings.TrimSpace(string(rs[65:80]))
+	d.PayorName = strings.TrimSpace(string(rs[80:110]))
+	d.OriginatorLongName = strings.TrimSpace(string(rs[110:140]))
+	d.UserID = strings.TrimSpace(string(rs[140:150]))
+	d.CrossRefNo = strings.TrimSpace(string(rs[150:169]))
+	d.ReturnInstitutionID = strings.TrimSpace(string(rs[169:178]))
+	d.ReturnAccountNo = strings.TrimSpace(string(rs[178:190]))
+	d.SundryInfo = strings.TrimSpace(string(rs[190:205]))
 	// filler at 205:227
-	d.SettlementCode = strings.TrimSpace(data[227:229])
+	d.SettlementCode = strings.TrimSpace(string(rs[227:229]))
 	d.RecordType = DebitRecord
 	return nil
 }

--- a/debit_return.go
+++ b/debit_return.go
@@ -103,34 +103,35 @@ func (d DebitReturn) Build() (string, error) {
 // The data passed in should be of length 240, the transaction length associated with the EFT file spec.
 func (d *DebitReturn) Parse(data string) error {
 	var err error
-	if len(data) != segmentLength {
+	rs := []rune(data)
+	if len(rs) != segmentLength {
 		return NewParseError(ErrInvalidRecordLength, "")
 	}
-	d.TxnType = TransactionType(data[:3])
-	d.Amount, err = parseNum(data[3:13])
+	d.TxnType = TransactionType(string(rs[:3]))
+	d.Amount, err = parseNum(string(rs[3:13]))
 	if err != nil {
 		return NewParseError(err, "failed to parse amount")
 	}
-	dueDate, err := parseDate(data[13:19])
+	dueDate, err := parseDate(string(rs[13:19]))
 	if err != nil {
 		return NewParseError(err, "failed to parse due date")
 	}
 	d.DueDate = &dueDate
-	d.InstitutionID = data[19:28]
-	d.PayorAccountNo = strings.TrimSpace(data[28:40])
-	d.ItemTraceNo = data[40:62]
-	d.StoredTransactionType = TransactionType(data[62:65])
-	d.OriginatorShortName = strings.TrimSpace(data[65:80])
-	d.PayorName = strings.TrimSpace(data[80:110])
-	d.OriginatorLongName = strings.TrimSpace(data[110:140])
-	d.UserID = strings.TrimSpace(data[140:150])
-	d.CrossRefNo = strings.TrimSpace(data[150:169])
-	d.OriginalInstitutionID = strings.TrimSpace(data[169:178])
-	d.OriginalAccountNo = strings.TrimSpace(data[178:190])
-	d.SundryInfo = strings.TrimSpace(data[190:205])
-	d.OriginalItemTraceNo = strings.TrimSpace(data[205:227])
-	d.SettlementCode = strings.TrimSpace(data[227:229])
-	d.InvalidDataElementID = strings.TrimSpace(data[229:240])
+	d.InstitutionID = string(rs[19:28])
+	d.PayorAccountNo = strings.TrimSpace(string(rs[28:40]))
+	d.ItemTraceNo = string(rs[40:62])
+	d.StoredTransactionType = TransactionType(string(rs[62:65]))
+	d.OriginatorShortName = strings.TrimSpace(string(rs[65:80]))
+	d.PayorName = strings.TrimSpace(string(rs[80:110]))
+	d.OriginatorLongName = strings.TrimSpace(string(rs[110:140]))
+	d.UserID = strings.TrimSpace(string(rs[140:150]))
+	d.CrossRefNo = strings.TrimSpace(string(rs[150:169]))
+	d.OriginalInstitutionID = strings.TrimSpace(string(rs[169:178]))
+	d.OriginalAccountNo = strings.TrimSpace(string(rs[178:190]))
+	d.SundryInfo = strings.TrimSpace(string(rs[190:205]))
+	d.OriginalItemTraceNo = strings.TrimSpace(string(rs[205:227]))
+	d.SettlementCode = strings.TrimSpace(string(rs[227:229]))
+	d.InvalidDataElementID = strings.TrimSpace(string(rs[229:240]))
 	d.RecordType = ReturnDebitRecord
 	return nil
 }

--- a/debit_return_test.go
+++ b/debit_return_test.go
@@ -85,7 +85,7 @@ func TestBuildDebitReturn(t *testing.T) {
 		},
 		"non ascii character": {
 			in:             NewDebitReturn("400", 999, &date, "123456789", "123456789012", "0000000000000000000000", "śhôrt-ñàmè", "réçëîvér ńámê", "LÖŃG-Ñämė", "123456789", "210987654321", "040201", WithUserID("54321"), WithCrossRefNo("123"), WithSettlementCode("01")),
-			expectedOutput: "40000000009990232411234567891234567890120000000000000000000000000short-name     receiver name                 LONG-Name                     54321     123                123456789210987654321               00000000000000000402010100000000000",
+			expectedOutput: "40000000009990232411234567891234567890120000000000000000000000000śhôrt-ñàmèréçëîvér ńámê         LÖŃG-Ñämė                54321     123                123456789210987654321               00000000000000000402010100000000000",
 		},
 	}
 	for name, tc := range cases {

--- a/debit_reverse.go
+++ b/debit_reverse.go
@@ -60,33 +60,34 @@ func NewDebitReverse(
 // The data passed in should be of length 240, the transaction length associated with the EFT file spec.
 func (d *DebitReverse) Parse(data string) error {
 	var err error
-	if len(data) != segmentLength {
+	rs := []rune(data)
+	if len(rs) != segmentLength {
 		return NewParseError(ErrInvalidRecordLength, "")
 	}
-	d.TxnType = TransactionType(data[:3])
-	d.Amount, err = parseNum(data[3:13])
+	d.TxnType = TransactionType(string(rs[:3]))
+	d.Amount, err = parseNum(string(rs[3:13]))
 	if err != nil {
 		return NewParseError(err, "failed to parse amount")
 	}
-	dateFundsAvail, err := parseDate(data[13:19])
+	dateFundsAvail, err := parseDate(string(rs[13:19]))
 	if err != nil {
 		return NewParseError(err, "failed to parse date funds available")
 	}
 	d.DueDate = &dateFundsAvail
-	d.InstitutionID = data[19:28]
-	d.PayorAccountNo = strings.TrimSpace(data[28:40])
-	d.ItemTraceNo = data[40:62]
-	d.StoredTransactionType = TransactionType(data[62:65])
-	d.OriginatorShortName = strings.TrimSpace(data[65:80])
-	d.PayorName = strings.TrimSpace(data[80:110])
-	d.OriginatorLongName = strings.TrimSpace(data[110:140])
-	d.UserID = strings.TrimSpace(data[140:150])
-	d.CrossRefNo = strings.TrimSpace(data[150:169])
-	d.ReturnInstitutionID = strings.TrimSpace(data[169:178])
-	d.ReturnAccountNo = strings.TrimSpace(data[178:190])
-	d.SundryInfo = strings.TrimSpace(data[190:205])
-	d.OriginalItemTraceNo = strings.TrimSpace(data[205:227])
-	d.SettlementCode = strings.TrimSpace(data[227:229])
+	d.InstitutionID = string(rs[19:28])
+	d.PayorAccountNo = strings.TrimSpace(string(rs[28:40]))
+	d.ItemTraceNo = string(rs[40:62])
+	d.StoredTransactionType = TransactionType(string(rs[62:65]))
+	d.OriginatorShortName = strings.TrimSpace(string(rs[65:80]))
+	d.PayorName = strings.TrimSpace(string(rs[80:110]))
+	d.OriginatorLongName = strings.TrimSpace(string(rs[110:140]))
+	d.UserID = strings.TrimSpace(string(rs[140:150]))
+	d.CrossRefNo = strings.TrimSpace(string(rs[150:169]))
+	d.ReturnInstitutionID = strings.TrimSpace(string(rs[169:178]))
+	d.ReturnAccountNo = strings.TrimSpace(string(rs[178:190]))
+	d.SundryInfo = strings.TrimSpace(string(rs[190:205]))
+	d.OriginalItemTraceNo = strings.TrimSpace(string(rs[205:227]))
+	d.SettlementCode = strings.TrimSpace(string(rs[227:229]))
 	d.RecordType = DebitReverseRecord
 	return nil
 }

--- a/debit_reverse_test.go
+++ b/debit_reverse_test.go
@@ -85,7 +85,7 @@ func TestBuildDebitReverse(t *testing.T) {
 		},
 		"non-ascii characters": {
 			in:             NewDebitReverse("400", 999, &date, "123456789", "123456789012", "0000000000000000000000", "śhôrt-ñàmè", "réçëîvér ńámê", "LÖŃG-Ñämė", "123456789", "210987654321", "040201", WithUserID("54321"), WithCrossRefNo("123"), WithSettlementCode("01")),
-			expectedOutput: "40000000009990232411234567891234567890120000000000000000000000000short-name     receiver name                 LONG-Name                     54321     123                123456789210987654321               00000000000000000402010100000000000",
+			expectedOutput: "40000000009990232411234567891234567890120000000000000000000000000śhôrt-ñàmèréçëîvér ńámê         LÖŃG-Ñämė                54321     123                123456789210987654321               00000000000000000402010100000000000",
 		},
 	}
 	for name, tc := range cases {

--- a/debit_test.go
+++ b/debit_test.go
@@ -83,7 +83,7 @@ func TestBuildDebitTxn(t *testing.T) {
 		},
 		"non ascii characters": {
 			in:             NewDebit("400", 999, &date, "123456789", "123456789012", "", "śhôrt-ñàmè", "réçëîvér ńámê", "LÖŃG-Ñämė", "123456789", "210987654321", WithUserID("54321"), WithCrossRefNo("123"), WithSettlementCode("01")),
-			expectedOutput: "40000000009990232411234567891234567890120000000000000000000000000short-name     receiver name                 LONG-Name                     54321     123                123456789210987654321                                     0100000000000",
+			expectedOutput: "40000000009990232411234567891234567890120000000000000000000000000śhôrt-ñàmèréçëîvér ńámê         LÖŃG-Ñämė                54321     123                123456789210987654321                                     0100000000000",
 		},
 	}
 	for name, tc := range cases {

--- a/file_footer.go
+++ b/file_footer.go
@@ -1,7 +1,6 @@
 package cadeft
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 )
@@ -48,8 +47,9 @@ func NewFileFooter(recordHeader RecordHeader, txns []Transaction) *FileFooter {
 // Parse will take in a serialized footer record of type Z and parse the amounts into a FileFooter struct
 func (ff *FileFooter) Parse(line string) error {
 	var err error
-	if len(line) < zRecordMinLength {
-		return errors.New("footer is too short")
+	rs := []rune(line)
+	if len(rs) < zRecordMinLength {
+		return fmt.Errorf("footer is too short")
 	}
 
 	recordHeader := RecordHeader{}
@@ -58,46 +58,46 @@ func (ff *FileFooter) Parse(line string) error {
 		return fmt.Errorf("failed to parse record header for footer: %w", err)
 	}
 	ff.RecordHeader = recordHeader
-	ff.TotalValueOfDebit, err = parseNum(line[24:38])
+	ff.TotalValueOfDebit, err = parseNum(string(rs[24:38]))
 	if err != nil {
 		return fmt.Errorf("failed to parse total value of debit: %w", err)
 	}
-	ff.TotalCountOfDebit, err = parseNum(line[38:46])
+	ff.TotalCountOfDebit, err = parseNum(string(rs[38:46]))
 	if err != nil {
 		return fmt.Errorf("failed to parse total count of debit: %w", err)
 	}
-	ff.TotalValueOfCredit, err = parseNum(line[46:60])
+	ff.TotalValueOfCredit, err = parseNum(string(rs[46:60]))
 	if err != nil {
 		return fmt.Errorf("failed to parse total value of credit: %w", err)
 	}
-	ff.TotalCountOfCredit, err = parseNum(line[60:68])
+	ff.TotalCountOfCredit, err = parseNum(string(rs[60:68]))
 	if err != nil {
 		return fmt.Errorf("failed to parse total count of credit: %w", err)
 	}
-	valERecordSegment := line[68:82]
+	valERecordSegment := string(rs[68:82])
 	if !isFillerString(valERecordSegment) {
 		if ff.TotalValueOfERecords, err = parseNum(valERecordSegment); err != nil {
 			return fmt.Errorf("failed to parse total value of E records: %w", err)
 		}
 	}
 
-	numERecordSegment := line[82:90]
+	numERecordSegment := string(rs[82:90])
 	if !isFillerString(numERecordSegment) {
 		if ff.TotalCountOfERecords, err = parseNum(numERecordSegment); err != nil {
 			return fmt.Errorf("failed to parse total count of E records: %w", err)
 		}
 	}
 
-	valFRecordsSegment := line[90:104]
+	valFRecordsSegment := string(rs[90:104])
 	if !isFillerString(valFRecordsSegment) {
-		if ff.TotalValueOfFRecords, err = parseNum(line[90:104]); err != nil {
+		if ff.TotalValueOfFRecords, err = parseNum(valFRecordsSegment); err != nil {
 			return fmt.Errorf("failed to parse total value of F records: %w", err)
 		}
 	}
 
-	numFRecordSegment := line[104:112]
+	numFRecordSegment := string(rs[104:112])
 	if !isFillerString(numFRecordSegment) {
-		if ff.TotalCountOfFRecords, err = parseNum(line[104:112]); err != nil {
+		if ff.TotalCountOfFRecords, err = parseNum(numFRecordSegment); err != nil {
 			return fmt.Errorf("failed to parse totoal count of F records: %w", err)
 		}
 	}

--- a/file_header.go
+++ b/file_header.go
@@ -1,7 +1,6 @@
 package cadeft
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -53,27 +52,26 @@ func WithDirectClearerCommunicationArea(comm string) HeaderOpts {
 
 func (fh *FileHeader) parse(line string) error {
 	var err error
-	recordHeader := RecordHeader{}
-	if len(line) < aRecordMinLength {
-		return errors.New("invalid header record length")
+	rs := []rune(line)
+	if len(rs) < aRecordMinLength {
+		return fmt.Errorf("invalid header record length")
 	}
-	err = recordHeader.parse(line)
-	if err != nil {
+	recordHeader := RecordHeader{}
+	if err = recordHeader.parse(line); err != nil {
 		return fmt.Errorf("failed to parse record header: %w", err)
 	}
 	fh.RecordHeader = recordHeader
-	creationDate, err := parseDate(line[24:30])
+	creationDate, err := parseDate(string(rs[24:30]))
 	if err != nil {
 		return fmt.Errorf("failed to parse creation date for file header: %w", err)
 	}
 	fh.CreationDate = &creationDate
-	fh.DestinationDataCenterNo, err = parseNum(line[30:35])
+	fh.DestinationDataCenterNo, err = parseNum(string(rs[30:35]))
 	if err != nil {
 		return fmt.Errorf("failed to parse destination data center for file header: %w", err)
 	}
-	fh.DirectClearerCommunicationArea = strings.TrimSpace(line[35:55])
-
-	fh.CurrencyCode = strings.TrimSpace(line[55:58])
+	fh.DirectClearerCommunicationArea = strings.TrimSpace(string(rs[35:55]))
+	fh.CurrencyCode = strings.TrimSpace(string(rs[55:58]))
 	return nil
 }
 

--- a/file_streamer.go
+++ b/file_streamer.go
@@ -16,7 +16,7 @@ import (
 type FileStreamer struct {
 	r              io.ReadSeeker
 	scanner        *bufio.Scanner
-	lineContents   string
+	lineContents   []rune
 	numTxnsPerLine int
 	currentTxn     int
 	currentLine    int
@@ -47,7 +47,7 @@ func (fs FileStreamer) GetHeader() (*FileHeader, error) {
 		return nil, errors.New("file header is empty")
 	}
 
-	recType, err := parseRecordType(string(line[0]))
+	recType, err := parseRecordType(string([]rune(line)[:1]))
 	if err != nil {
 		return nil, fmt.Errorf("file header not found: %w", err)
 	}
@@ -74,7 +74,7 @@ func (fs FileStreamer) GetFooter() (*FileFooter, error) {
 		if len(line) < 1 {
 			return nil, errors.New("line too short to determine record type")
 		}
-		recType := line[:1]
+		recType := string([]rune(line)[:1])
 		if recType == string(FooterRecord) {
 			ff := &FileFooter{}
 			if err := ff.Parse(line); err != nil {
@@ -99,7 +99,7 @@ func (fs *FileStreamer) ScanTxn() (Transaction, error) {
 			return nil, io.EOF
 
 		}
-		if len(fs.scanner.Text()) == 0 || !isHeaderRecordType(string(fs.scanner.Text()[0])) {
+		if len(fs.scanner.Text()) == 0 || !isHeaderRecordType(string([]rune(fs.scanner.Text())[:1])) {
 			return nil, errors.New("first line in file is not a header record")
 		}
 		fs.currentLine++
@@ -120,7 +120,7 @@ func (fs *FileStreamer) ScanTxn() (Transaction, error) {
 			return nil, fmt.Errorf("failed to read transaction line: %w", err)
 		}
 
-		fs.lineContents = line
+		fs.lineContents = []rune(line)
 
 		if len(fs.lineContents) == 0 || isFooterRecord(string(fs.lineContents[0])) {
 			return nil, io.EOF
@@ -142,7 +142,7 @@ func (fs *FileStreamer) ScanTxn() (Transaction, error) {
 		return nil, io.EOF
 	}
 
-	recordType, err := parseRecordType(fs.lineContents[:1])
+	recordType, err := parseRecordType(string(fs.lineContents[:1]))
 	if err != nil {
 		fs.currentTxn, fs.numTxnsPerLine = 0, 0
 		return nil, fmt.Errorf("unrecognized record type at line %d: %w", fs.currentLine, err)
@@ -163,43 +163,44 @@ func (fs *FileStreamer) ScanTxn() (Transaction, error) {
 	if endIdx > len(txnsSegment) {
 		return nil, fmt.Errorf("txn segment bounds out of range at line %d", fs.currentLine)
 	}
+	seg := string(txnsSegment[startIdx:endIdx])
 
 	var txn Transaction
 	switch recordType {
 	case DebitRecord:
 		d := Debit{}
-		err = d.Parse(txnsSegment[startIdx:endIdx])
+		err = d.Parse(seg)
 		if err != nil {
 			return nil, NewParseError(err, "")
 		}
 		txn = &d
 	case CreditRecord:
 		c := Credit{}
-		if err := c.Parse(txnsSegment[startIdx:endIdx]); err != nil {
+		if err := c.Parse(seg); err != nil {
 			return nil, newStreamParseError(err, string(DebitRecord), fs.currentTxn, fs.currentLine)
 		}
 		txn = &c
 	case ReturnDebitRecord:
 		dr := DebitReturn{}
-		if err := dr.Parse(txnsSegment[startIdx:endIdx]); err != nil {
+		if err := dr.Parse(seg); err != nil {
 			return nil, newStreamParseError(err, string(ReturnDebitRecord), fs.currentTxn, fs.currentLine)
 		}
 		txn = &dr
 	case ReturnCreditRecord:
 		cr := CreditReturn{}
-		if err := cr.Parse(txnsSegment[startIdx:endIdx]); err != nil {
+		if err := cr.Parse(seg); err != nil {
 			return nil, newStreamParseError(err, string(ReturnCreditRecord), fs.currentTxn, fs.currentLine)
 		}
 		txn = &cr
 	case CreditReverseRecord:
 		cr := CreditReverse{}
-		if err := cr.Parse(txnsSegment[startIdx:endIdx]); err != nil {
+		if err := cr.Parse(seg); err != nil {
 			return nil, newStreamParseError(err, string(CreditReverseRecord), fs.currentTxn, fs.currentLine)
 		}
 		txn = &cr
 	case DebitReverseRecord:
 		dr := DebitReverse{}
-		if err := dr.Parse(txnsSegment[startIdx:endIdx]); err != nil {
+		if err := dr.Parse(seg); err != nil {
 			return nil, newStreamParseError(err, string(DebitReverseRecord), fs.currentTxn, fs.currentLine)
 		}
 		txn = &dr

--- a/normalize.go
+++ b/normalize.go
@@ -1,27 +1,13 @@
 package cadeft
 
-import (
-	"fmt"
-	"unicode"
+import "golang.org/x/text/unicode/norm"
 
-	"golang.org/x/text/unicode/norm"
-
-	"golang.org/x/text/runes"
-	"golang.org/x/text/transform"
-)
-
-// normalizer removes diacritical characters and replaces them with their ASCII representation
-var normalizer = transform.Chain(norm.NFD, runes.Remove(runes.In(unicode.Mn)), runes.Remove(runes.In(unicode.So)), norm.NFC)
-
+// normalize returns the NFC-canonical form of in. Previous versions of
+// this function aborted on non-ASCII input; that's gone — the byte-indexed
+// fixed-width parsers in reader.go and the per-record Parse methods are
+// rune-indexed (Spendbase fork 2026-05-04), so French / accented Latin
+// flows through unchanged. NFC is applied so equivalent forms (precomposed
+// "É" U+00C9 vs. decomposed "E"+U+0301) compare equal downstream.
 func normalize(in string) (string, error) {
-	s, _, err := transform.String(normalizer, in)
-	if err != nil {
-		return "", err
-	}
-	for i := 0; i < len(s); i++ {
-		if s[i] > unicode.MaxASCII {
-			return "", fmt.Errorf("failed to normalize rune %c", s[i])
-		}
-	}
-	return s, nil
+	return norm.NFC.String(in), nil
 }

--- a/normalize_test.go
+++ b/normalize_test.go
@@ -1,20 +1,15 @@
 package cadeft
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-func TestNormalize(t *testing.T) {
-	sampleText := `Álfréd, the hândŷ mân, häd ēârnėd a rěsćūě. He dîd not ùsě cômplètě cîrcûmfle chèmîcáls, âlthoûgh hě hăd an ōppôrtûnĭtý. His jôb wäs to mĕasure ćērtăin tȇmpérâtûrēs, whîle bėâring a lĭttle mâcron êmblēm. He nėver sǫught to âssûme thě sȗbtlě dîaresîs, prėferrĭng to cõncěntrāte on cédilla mèâsureměnts ând ťìlděd äccentūâtions. Hė wãs rěgǫrděd as thě môst skīllful of thě sènsiblě sųmmed ǫgněk ênthusīâsts.`
-	expected := `Alfred, the handy man, had earned a rescue. He did not use complete circumfle chemicals, although he had an opportunity. His job was to measure certain temperatures, while bearing a little macron emblem. He never sought to assume the subtle diaresis, preferring to concentrate on cedilla measurements and tilded accentuations. He was regorded as the most skillful of the sensible summed ognek enthusiasts.`
-	normal, err := normalize(sampleText)
+func TestNormalize_PreservesAccents(t *testing.T) {
+	in := "Nom Émetteur — accents survive"
+	out, err := normalize(in)
 	require.NoError(t, err)
-	require.Equal(t, expected, normal)
-
-	// We attempt to normalize diacritical but non ascii and non diacritical letters are errors.
-	notAscii := `Лорем ипсум Λορεμ ι成空援光必 मजबुत प्रमान वर्तमान`
-	_, err = normalize(notAscii)
-	require.Error(t, err)
+	require.True(t, strings.Contains(out, "Émetteur"), "normalize stripped accents: got %q", out)
 }

--- a/reader.go
+++ b/reader.go
@@ -2,7 +2,6 @@ package cadeft
 
 import (
 	"bufio"
-	"errors"
 	"fmt"
 	"io"
 )
@@ -22,15 +21,20 @@ func NewReader(in io.Reader) *Reader {
 // If no errors are encountered a populated File object is returned that contains the Header, Transactions and Footer.
 // Use the FileStreamer object to be able ignore errors and proceed parsing the file.
 func (r *Reader) ReadFile() (File, error) {
+	// Allow CPA lines longer than bufio's default 64 KiB buffer. CPA Std
+	// 005 lines are at most 1,464 chars; in UTF-8 with French chars they
+	// can stretch a bit past that. 1 MiB is plenty.
+	r.scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
 	for r.scanner.Scan() {
 		line, err := normalize(r.scanner.Text())
 		if err != nil {
 			return File{}, fmt.Errorf("failed to read line: %w", err)
 		}
-		if len(line) == 0 {
+		if line == "" {
 			continue
 		}
-		recordType := line[:1]
+		recordType := string([]rune(line)[:1])
 		if recordType == string(HeaderRecord) {
 			if err := r.parseARecord(line); err != nil {
 				return File{}, fmt.Errorf("failed to parse header: %w", err)
@@ -49,8 +53,8 @@ func (r *Reader) ReadFile() (File, error) {
 }
 
 func (r *Reader) parseARecord(data string) error {
-	if len(data) < aRecordMinLength {
-		return errors.New("record type A is not required length")
+	if len([]rune(data)) < aRecordMinLength {
+		return fmt.Errorf("record type A is not required length")
 	}
 	fHeader := &FileHeader{}
 	if err := fHeader.parse(data); err != nil {
@@ -61,75 +65,73 @@ func (r *Reader) parseARecord(data string) error {
 }
 
 func (r *Reader) parseTxnRecord(data string) error {
-	if len(data) < commonRecordDataLength {
-		return fmt.Errorf("txn record shorter than common header length %d: got %d", commonRecordDataLength, len(data))
+	rs := []rune(data)
+	if len(rs) < commonRecordDataLength {
+		return fmt.Errorf("txn record shorter than common header length %d: got %d", commonRecordDataLength, len(rs))
 	}
-	if len(data[commonRecordDataLength:])%segmentLength != 0 {
-		return fmt.Errorf("record length is not valid multiple of 260, partial txn: %d", len(data[commonRecordDataLength:]))
+	if len(rs[commonRecordDataLength:])%segmentLength != 0 {
+		return fmt.Errorf("record length is not valid multiple of %d, partial txn: %d", segmentLength, len(rs[commonRecordDataLength:]))
 	}
-	rawTxnSegment := data[commonRecordDataLength:]
-	numSegments := len(rawTxnSegment) / segmentLength
-	// make this into a function
-	recType, err := parseRecordType(data[:1])
+	body := rs[commonRecordDataLength:]
+	numSegments := len(body) / segmentLength
+
+	recType, err := parseRecordType(string(rs[:1]))
 	if err != nil {
 		return fmt.Errorf("failed to parse transaction: %w", err)
 	}
 
-	startIdx := 0
-	endIdx := segmentLength
 	for i := 0; i < numSegments; i++ {
-		if isFillerString(rawTxnSegment[startIdx:endIdx]) {
+		seg := string(body[i*segmentLength : (i+1)*segmentLength])
+		if isFillerString(seg) {
 			continue
 		}
 		switch recType {
 		case DebitRecord:
 			debit := Debit{}
-			if err := debit.Parse(rawTxnSegment[startIdx:endIdx]); err != nil {
+			if err := debit.Parse(seg); err != nil {
 				return fmt.Errorf("failed to parse debit transaction: %w", err)
 			}
 			r.File.Txns = append(r.File.Txns, &debit)
 		case CreditRecord:
 			credit := Credit{}
-			if err := credit.Parse(rawTxnSegment[startIdx:endIdx]); err != nil {
+			if err := credit.Parse(seg); err != nil {
 				return fmt.Errorf("failed to parse credit transaction: %w", err)
 			}
 			r.File.Txns = append(r.File.Txns, &credit)
 		case ReturnDebitRecord:
 			debitReturn := DebitReturn{}
-			if err := debitReturn.Parse(rawTxnSegment[startIdx:endIdx]); err != nil {
+			if err := debitReturn.Parse(seg); err != nil {
 				return fmt.Errorf("failed to parse debit return transaction: %w", err)
 			}
 			r.File.Txns = append(r.File.Txns, &debitReturn)
 		case ReturnCreditRecord:
 			creditReturns := CreditReturn{}
-			if err := creditReturns.Parse(rawTxnSegment[startIdx:endIdx]); err != nil {
+			if err := creditReturns.Parse(seg); err != nil {
 				return fmt.Errorf("failed to parse credit return transaction: %w", err)
 			}
 			r.File.Txns = append(r.File.Txns, &creditReturns)
 		case CreditReverseRecord:
 			creditReverse := CreditReverse{}
-			if err := creditReverse.Parse(rawTxnSegment[startIdx:endIdx]); err != nil {
+			if err := creditReverse.Parse(seg); err != nil {
 				return fmt.Errorf("failed to parse credit reverse transaction: %w", err)
 			}
 			r.File.Txns = append(r.File.Txns, &creditReverse)
 		case DebitReverseRecord:
 			debitReverseRecord := DebitReverse{}
-			if err := debitReverseRecord.Parse(rawTxnSegment[startIdx:endIdx]); err != nil {
+			if err := debitReverseRecord.Parse(seg); err != nil {
 				return fmt.Errorf("failed to parse debit reverse transaction: %w", err)
 			}
 			r.File.Txns = append(r.File.Txns, &debitReverseRecord)
 		case HeaderRecord, FooterRecord, NoticeOfChangeRecord, NoticeOfChangeHeader, NoticeOfChangeFooter:
 			return fmt.Errorf("unexpected %s record", recType)
 		}
-		startIdx = endIdx
-		endIdx += segmentLength
 	}
 	return nil
 }
 
 func (r *Reader) parseZRecord(data string) error {
-	if len(data) < zRecordMinLength {
-		return errors.New("z record does not contain minimum amount of data")
+	if len([]rune(data)) < zRecordMinLength {
+		return fmt.Errorf("z record does not contain minimum amount of data")
 	}
 
 	footer := &FileFooter{}

--- a/record_header.go
+++ b/record_header.go
@@ -17,16 +17,20 @@ type RecordHeader struct {
 
 func (rh *RecordHeader) parse(line string) error {
 	var err error
-	if rh.RecordType, err = convertRecordType(line[:1]); err != nil {
+	rs := []rune(line)
+	if len(rs) < 24 {
+		return fmt.Errorf("record header line too short")
+	}
+	if rh.RecordType, err = convertRecordType(string(rs[:1])); err != nil {
 		return fmt.Errorf("faield to parse RecordHeader: %w", err)
 	}
 
-	if rh.recordCount, err = parseNum(line[1:10]); err != nil {
+	if rh.recordCount, err = parseNum(string(rs[1:10])); err != nil {
 		return fmt.Errorf("failed to parse RecordCount: %w", err)
 	}
 
-	rh.OriginatorID = strings.TrimSpace(line[10:20])
-	if rh.FileCreationNum, err = parseNum(line[20:24]); err != nil {
+	rh.OriginatorID = strings.TrimSpace(string(rs[10:20]))
+	if rh.FileCreationNum, err = parseNum(string(rs[20:24])); err != nil {
 		return fmt.Errorf("failed to parse FileCreationNum: %w", err)
 	}
 


### PR DESCRIPTION
## What

CPA Std 005 accepts English and French Latin characters. The library was slicing fixed-width fields by **byte** index and then rejecting anything that did not fold to ASCII. Multi-byte French names (for example `Nom Émetteur`) were corrupted or rejected with `failed to normalize rune`.

This ports the Spendbase fork: parse every fixed-width field by **rune** index, keep NFC-canonical Unicode, and stop ASCII-folding names.

## Source

Cherry-picked from [Spendbase/cadeft@889e82e](https://github.com/Spendbase/cadeft/commit/889e82e394f082f44945e8bd9dc010c40fa02e0b) by **Elvin Rzayev**.

The fork also renamed the Go module; that part is not included.

## Tests

`go test ./...` passes.