### PR TITLE
Enable CodeQL on push/PR and pin x/net v0.58.0

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -2,10 +2,10 @@
 name: CodeQL Analysis
 
 on:
-  # push:
-  # pull_request:
-  # schedule:
-  #   - cron: '0 10 * * 0'
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 10 * * 0'
   workflow_dispatch:
 
 permissions:

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/go-playground/validator/v10 v10.30.3
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/stretchr/testify v1.12.0
+	golang.org/x/net v0.58.0
 	golang.org/x/text v0.41.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/stretchr/testify v1.12.0 h1:K6Mr6jO9JICuend/5xzTM03ydSV3vdNRYAdPSukj8
 github.com/stretchr/testify v1.12.0/go.mod h1:bOYBZb5qJ00vPzWfIqBUZPaxK8jWiXc6d3ErP4Ca9Gw=
 golang.org/x/crypto v0.55.0 h1:+KWHjbgOaAQ66dh/YlkZKHlz9ZUlq61AFirAR9ntP8M=
 golang.org/x/crypto v0.55.0/go.mod h1:uq0V9dE/fzQuJtbnL+2EhWOE63vo164FY8xqEnV9xis=
+golang.org/x/net v0.58.0 h1:ynWG7rqYi4ccpTEuPZ2QGWHktVEM9DMCj9yzDE0Q7To=
+golang.org/x/net v0.58.0/go.mod h1:YwCddHnFlT7eLQqVprV19OnhLGtc5xOKgE0RyqgfWAU=
 golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
 golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/text v0.41.0 h1:vz/seA0lnX87Othu2f/0L24RcgrXD9/YFTSuGjj3rH8=

--- a/tools.go
+++ b/tools.go
@@ -1,0 +1,7 @@
+//go:build tools
+
+package cadeft
+
+// Pin golang.org/x/net to a patched release so Dependabot can resolve
+// GHSA-5cv4-jp36-h3mw (HTML parser DoS in versions before v0.55.0).
+import _ "golang.org/x/net/idna"


### PR DESCRIPTION
## Why CodeQL never ran

`.github/workflows/codeql.yaml` only had `workflow_dispatch`. `push`, `pull_request`, and `schedule` were commented out, so Actions never started CodeQL on commits or PRs.

This restores those triggers (and keeps manual `workflow_dispatch`), matching metro2/ach/iso8583. Action pins and `persist-credentials: false` stay in place.

## Dependabot alert 13

[GHSA-5cv4-jp36-h3mw](https://github.com/moov-io/cadeft/security/dependabot/13) (`golang.org/x/net` < 0.55.0). Require `v0.58.0` so the graph has a patched version.

## Tests

`go test ./...` passes.