### PR TITLE
Restore Dependabot for Go modules and Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: daily
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## What

Puts Dependabot version updates back so they run **daily**.

Only the ecosystems that exist in this repo are enabled:

- `gomod` in `/`
- `github-actions` in `/`

`docker` and `bundler` (`/docs`) are left out. Those paths are not in cadeft, and they were the failing Dependabot Updates jobs.

The 7-day cooldown stays so zizmor stays happy.